### PR TITLE
changed sql_connector.php to not store passwords in repo'd files

### DIFF
--- a/sql_connector.php
+++ b/sql_connector.php
@@ -1,6 +1,11 @@
 <?php
+
+$config = parse_ini_file( 'config.ini' );
+
+$password = $config['password'];
+
 DEFINE ('DB_USER','root');
-DEFINE ('DB_PASSWORD', '');
+DEFINE ('DB_PASSWORD', $password);
 DEFINE ('DB_HOST','localhost');
 DEFINE ('DB_NAME', 'cs499');
 


### PR DESCRIPTION
Very simple change, built sql_connector.php to pull password from a config file instead of storing the password in plaintext. This way sql_connector.php can be commited to the repo without revealing the password.